### PR TITLE
fix(compile): fix installing files

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -106,10 +106,15 @@ sc::_::task_finish
 
 sc::_::task_start "Installing"
 
-if ! mv "${tmp_dir}/grafana-v${version}/"* --target-directory="${build_dir}" 2>/dev/null; then
-    sc::_::task_fail "An error occured while installing the files. Aborting."
-    exit
-fi
+# Use brace expansion to handle the optional prefixing 'v':
+for src in "${tmp_dir}"/grafana-{v,}"${version}"; do
+    if [[ -d "${src}" ]]; then
+        if ! mv "${src}"/* --target-directory="${build_dir}"; then
+            sc::_::task_fail "An error occured while installing the files. Aborting."
+            exit
+        fi
+    fi
+done
 
 sc::_::task_finish
 


### PR DESCRIPTION
Grafana now uses a directory named with a version without the prefixing 'v':
- Before: `grafana-v13.0.2`
- Now: `grafana-13.0.2`
This patch allows to handle both cases.